### PR TITLE
using c10::intrusive_ptr<c10d::ProcessGroup> as argument from python

### DIFF
--- a/include/flux/ths_op/flux_shm.h
+++ b/include/flux/ths_op/flux_shm.h
@@ -16,20 +16,22 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <cuda_runtime_api.h>
 #include <torch/torch.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <vector>
+#include "c10/util/intrusive_ptr.h"
 namespace bytedance::flux {
 
-void init_flux_shm(c10d::ProcessGroup &pg);
+void init_flux_shm(c10::intrusive_ptr<c10d::ProcessGroup> pg);
 torch::Tensor flux_create_tensor(
     const std::vector<int64_t> &shape,
     c10::ScalarType dtype,
-    c10::optional<c10d::ProcessGroup> pg = c10::nullopt);
+    c10::intrusive_ptr<c10d::ProcessGroup> pg = nullptr);
 std::vector<torch::Tensor> flux_create_tensor_list(
     const std::vector<int64_t> &shape,
     c10::ScalarType dtype,
-    c10::optional<c10d::ProcessGroup> pg = c10::nullopt);
+    c10::intrusive_ptr<c10d::ProcessGroup> pg = nullptr);
 void flux_barrier_all_on_stream(
     cudaStream_t stream,
     c10::optional<std::vector<torch::Tensor>> barrier_tensors = c10::nullopt,
@@ -41,7 +43,9 @@ void pyflux_barrier_all_on_stream(
 
 // suggest use the functions above if possible
 std::vector<torch::Tensor> cudaipc_create_tensor_list(
-    c10d::ProcessGroup &pg, const std::vector<int64_t> &shape, c10::ScalarType dtype);
+    c10::intrusive_ptr<c10d::ProcessGroup> pg,
+    const std::vector<int64_t> &shape,
+    c10::ScalarType dtype);
 
 #ifdef FLUX_SHM_USE_NVSHMEM
 std::vector<torch::Tensor> nvshmem_create_tensor_list(

--- a/include/flux/ths_op/ths_op.h
+++ b/include/flux/ths_op/ths_op.h
@@ -122,24 +122,24 @@ class ThsOpsInitRegistry {
   ThsOpsInitRegistry &operator=(const ThsOpsInitRegistry &) = delete;
 };
 
-struct DistEnvTP : public DistEnv, torch::CustomClassHolder {
-  c10d::ProcessGroup tp_group;
-  DistEnvTP(c10d::ProcessGroup tp_group, int nnodes = 1);
+struct DistEnvTP : public DistEnv {
+  c10::intrusive_ptr<c10d::ProcessGroup> tp_group;
+  DistEnvTP(c10::intrusive_ptr<c10d::ProcessGroup> tp_group, int nnodes = 1);
   std::string toString() const;
 };
 
-struct DistEnvTPWithEP : public DistEnv, torch::CustomClassHolder {
-  c10d::ProcessGroup tp_group;
-  c10::optional<c10d::ProcessGroup> ep_group;
+struct DistEnvTPWithEP : public DistEnv {
+  c10::intrusive_ptr<c10d::ProcessGroup> tp_group;
+  c10::intrusive_ptr<c10d::ProcessGroup> ep_group;
   int32_t ep_rank;
   int32_t ep_size;
   int32_t ffn_tp_size;
   int32_t ffn_tp_rank;
 
   DistEnvTPWithEP(
-      c10d::ProcessGroup tp_group,
+      c10::intrusive_ptr<c10d::ProcessGroup> tp_group,
       int nnodes = 1,
-      c10::optional<c10d::ProcessGroup> ep_group = c10::nullopt);
+      c10::intrusive_ptr<c10d::ProcessGroup> ep_group = nullptr);
   std::string toString() const;
 };
 

--- a/include/flux/ths_op/topo_utils.h
+++ b/include/flux/ths_op/topo_utils.h
@@ -22,14 +22,14 @@
 
 namespace bytedance::flux::topo_utils {
 
-ncclComm_t create_nccl_comm_with_processgroup(c10d::ProcessGroup &pg);
+ncclComm_t create_nccl_comm_with_processgroup(c10::intrusive_ptr<c10d::ProcessGroup> pg);
 
 bool is_topo_initialized();
 /**
  * call this function multi times, you will got some warnings and only runs once really
  * @param group: this should be a local group. if not, split it to a local group from outside
  */
-void initialize_topo(c10d::ProcessGroup &group);
+void initialize_topo(c10::intrusive_ptr<c10d::ProcessGroup> group);
 void initialize_topo(const std::vector<int> &device_ids);
 
 // has any NV-link supported GPU exists

--- a/pynvshmem/bootstrap/torch/bootstrap_torch.cpp
+++ b/pynvshmem/bootstrap/torch/bootstrap_torch.cpp
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 
+// don't own this. make use this lives longer than using this
 static c10d::ProcessGroup *pg = nullptr;
 static int nvshmem_initialized_torch = 0;
 

--- a/pynvshmem/src/functions.cpp
+++ b/pynvshmem/src/functions.cpp
@@ -24,13 +24,13 @@
 #include <vector>
 
 inline void
-init_with_c10d_pg(const c10d::ProcessGroup &c10_pg) {
+init_with_c10d_pg(c10::intrusive_ptr<c10d::ProcessGroup> c10_pg) {
   nvshmemx_init_attr_t init_attr;
-  init_attr.mpi_comm = (void *)&c10_pg;  // bad! pretend I'm the MPIComm
+  init_attr.mpi_comm = (void *)c10_pg.get();  // bad! pretend I'm the MPIComm
   nvshmemx_init_attr(NVSHMEMX_INIT_WITH_MPI_COMM, &init_attr);
   int mype = nvshmem_my_pe();
-  CHECK(c10_pg.getRank() == mype) << "NVShmem init: rank does not match PE!" << c10_pg.getRank()
-                                  << " vs " << mype;
+  CHECK(c10_pg->getRank() == mype)
+      << "NVShmem init: rank does not match PE!" << c10_pg->getRank() << " vs " << mype;
 }
 
 namespace {

--- a/src/cuda/utils.cc
+++ b/src/cuda/utils.cc
@@ -19,7 +19,6 @@
 #include <stdio.h>
 #include <string>
 #include <stdlib.h>
-// #define FLUX_DEBUG 0
 
 namespace bytedance::flux {
 


### PR DESCRIPTION

# the problem
related to https://github.com/bytedance/flux/issues/11


<img width="810" alt="image" src="https://github.com/bytedance/flux/assets/1913192/d9e2c66d-0a12-43c1-ab2a-6f9359045bc8">


# Why

c10d::ProcessGroup as a c10::intrusive_ptr_target can be copied or moved, but with refcount to 0, which causes c10d::ProcessGroup release_resources after the first call.

# Fix

using c10::intrusive_ptr<c10d::ProcessGroup> as argument instead.
