### PR TITLE
Remove pynvshmem import in gemm_rs_80.py

### DIFF
--- a/python/flux/gemm_rs_sm80.py
+++ b/python/flux/gemm_rs_sm80.py
@@ -19,7 +19,6 @@ from functools import partial
 import torch
 import torch.distributed as dist
 import flux
-from flux import pynvshmem
 from typing import Optional
 
 FLUX_GEMM_RS_INTER_NODE_GROUP = None


### PR DESCRIPTION
AFAICT, pynvshmem isn't used anywhere in this file, and the import results in errors when I build flux without nvshmem.