### PR TITLE
fix cuda>=12.8 build

### DIFF
--- a/include/flux/cuda/cuda_common_device.hpp
+++ b/include/flux/cuda/cuda_common_device.hpp
@@ -17,13 +17,15 @@
 
 #pragma once
 
+
 #include "cute/util/debug.hpp"
 #include "cute/util/print.hpp"
 #include "cutlass/detail/helper_macros.hpp"
 #include <cstddef>
 #include <cstring>
 
-#if defined(CUDA_VERSION) && CUDA_VERSION > 12080
+#include <cuda.h>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
 #include <cuda/atomic>
 #else
 #include <cuda/std/atomic>

--- a/src/gemm_rs/reduce_scatter_kernel.hpp
+++ b/src/gemm_rs/reduce_scatter_kernel.hpp
@@ -24,7 +24,6 @@
 #include <ostream>
 #include <type_traits>
 #include <cuda_runtime_api.h>
-#include <cuda/std/atomic>
 #include <utility>
 #include "cutlass/detail/helper_macros.hpp"
 #ifdef FLUX_SHM_USE_NVSHMEM
@@ -50,6 +49,13 @@
 #include "gemm_rs/reduce_scatter_barrier_struct.hpp"
 #ifdef FLUX_REDUCE_SCATTER_WITH_NCCL
 #include <nccl.h>
+#endif
+
+#include <cuda.h>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#include <cuda/atomic>
+#else
+#include <cuda/std/atomic>
 #endif
 
 #define NextRank(rank_) (((rank_) + 1) % kLocalWorldSize)

--- a/src/moe_ag_scatter/cutlass_impls/ag_scatter_gemm_grouped_with_absmax.h
+++ b/src/moe_ag_scatter/cutlass_impls/ag_scatter_gemm_grouped_with_absmax.h
@@ -37,7 +37,6 @@
 
 #pragma once
 
-
 #include "cutlass/cutlass.h"
 #include "cutlass/float8.h"
 #include "cutlass/matrix_coord.h"
@@ -45,7 +44,13 @@
 #include "cutlass/gemm/kernel/gemm_transpose_operands.h"
 #include <ctime>
 #include <type_traits>
+
+#include <cuda.h>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#include <cuda/atomic>
+#else
 #include <cuda/std/atomic>
+#endif
 #include "ag_scatter_grouped_problem_visitor.hpp"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/moe_gather_rs/cutlass_impls/gather_rs_gemm_grouped_with_absmax.h
+++ b/src/moe_gather_rs/cutlass_impls/gather_rs_gemm_grouped_with_absmax.h
@@ -52,8 +52,13 @@
 #include <type_traits>
 
 #include "cutlass/barrier.h"
-#include <cuda/std/atomic>
 
+#include <cuda.h>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#include <cuda/atomic>
+#else
+#include <cuda/std/atomic>
+#endif
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace cutlass {


### PR DESCRIPTION
Fix #105 #138 #142 
- CUDA_VERSION `>=` 12080 not `>`
- should include <cuda.h> to ensure `CUDA_VERSION` has been defined.